### PR TITLE
fix bug in encoding

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ before_install:
 node_js:
   - "0.10"
   - "0.11"
+  - "0.12"
+  - "iojs"
 env:
   - TEST_SUITE=test
   - TEST_SUITE=coveralls

--- a/async-shim.js
+++ b/async-shim.js
@@ -1,7 +1,7 @@
 var compat = require('./browser')
 
 process.on('message', function (m) {
-  var result = compat.pbkdf2Sync(m.password, m.salt, m.iterations, m.keylen, m.digest)
+  var result = compat.pbkdf2Sync(new Buffer(m.password, 'hex'), new Buffer(m.salt, 'hex'), m.iterations, m.keylen, m.digest)
 
   process.send(result.toString('hex'))
 })

--- a/index.js
+++ b/index.js
@@ -19,6 +19,11 @@ function asyncPBKDF2 (password, salt, iterations, keylen, digest, callback) {
   if (keylen < 0) {
     throw new TypeError('Bad key length')
   }
+  if (typeof password === 'string')
+    password = new Buffer(password)
+
+  if (typeof salt === 'string')
+    salt = new Buffer(salt)
 
   var child = fork(path.resolve(__dirname, 'async-shim.js'))
 
@@ -31,8 +36,8 @@ function asyncPBKDF2 (password, salt, iterations, keylen, digest, callback) {
   })
 
   child.send({
-    password: password.toString(),
-    salt: salt.toString(),
+    password: password.toString('hex'),
+    salt: salt.toString('hex'),
     iterations: iterations,
     keylen: keylen,
     digest: digest

--- a/test/index.js
+++ b/test/index.js
@@ -79,6 +79,32 @@ function runTests(compat, name) {
           })
         })
       })
+
+      describe('encoding bug', function () {
+         var password = 'test'
+          var salt = new Buffer('7b970da6a2fddaba', 'hex')
+          var iterations = 1000
+          var length = 64
+          var algo = 'sha512'
+          var expected = '7c89cceaea1811b0aeaf23587fadb4b80580d9b26c7e7489ec56f9f0a84c1b612c788ddfb4a86dee8e5be70d4742b84ff3e818e3b83aa68d21db5b4d9f70dc8e'
+         
+        it("should get the correct result sync", function () {
+          var result = compat.pbkdf2Sync(password, salt, iterations, length, algo).toString('hex')
+          assert.equal(result, expected)
+        })
+
+        it("should get the correct result async", function (done) {
+          compat.pbkdf2(password, salt, iterations, length, algo, function (err, res) {
+            if (err) {
+              return done(err)
+            }
+            var result = res.toString('hex')
+            assert.equal(result, expected)
+            done()
+          })
+          
+        })
+      })
     })
   })
 }


### PR DESCRIPTION
basically you can't send a buffer to a different process so I had to stringify it, but I was just doing toString and that was aparently not round tripping back to a buffer correctly, there would have also likely been an issue with passwords that included weird non printable charicters